### PR TITLE
fix: Add timestamp column in scannings table (rubocop error)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    snapcher (0.1.3)
+    snapcher (0.1.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/generators/snapcher/templates/install.rb
+++ b/lib/generators/snapcher/templates/install.rb
@@ -11,6 +11,7 @@ class <%= migration_class_name %> < <%= migration_parent %>
       t.column :after_params, :string
       t.column :action, :string
       t.column :created_at, :datetime
+      t.timestamps null: false
     end
   end
 

--- a/lib/snapcher/version.rb
+++ b/lib/snapcher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Snapcher
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
I ran into this Rubocop error.
This pull request will resolve your issue.

https://www.rubydoc.info/gems/rubocop/0.58.0/RuboCop/Cop/Rails/CreateTableWithTimestamps