### PR TITLE
Change option to snatch user

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    snapcher (0.3.0)
+    snapcher (0.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If the "Snatcher" column you want to capture is not user_id, you can specify thi
 
 ```ruby
 class User < ActiveRecord::Base
-  scanning column_name: "name", change_user_column: "id"
+  scanning column_name: "name", snatch_user: "id"
 end
 ```
 

--- a/lib/snapcher.rb
+++ b/lib/snapcher.rb
@@ -12,7 +12,7 @@ module Snapcher
 
   class << self
     attr_accessor :column_name, :current_user
-    attr_accessor :change_user_column
+    attr_accessor :snatch_user
     attr_writer :scanning_class
 
     def scanning_class

--- a/lib/snapcher/junker.rb
+++ b/lib/snapcher/junker.rb
@@ -63,7 +63,7 @@ module Snapcher
       end
 
       def snatch
-        snapcher_attributes[snapcher_options[:change_user_column]] || snapcher_attributes["user_id"]
+        snapcher_attributes[snapcher_options[:snatch_user]] || snapcher_attributes["user_id"]
       end
 
       def scanning_change_values
@@ -82,8 +82,6 @@ module Snapcher
         snapcher_attributes = filter_encrypted_attrs(attributes)
         filtered_changes = scanning_change_values
         monitoring_column_name = snapcher_options[:column_name]
-        change_user_column = snapcher_options[:change_user_column]
-
         return if filtered_changes[monitoring_column_name.to_s].nil?
 
         before_params = filtered_changes[monitoring_column_name.to_s][0]

--- a/lib/snapcher/version.rb
+++ b/lib/snapcher/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Snapcher
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/sample-app/Gemfile.lock
+++ b/sample-app/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    snapcher (0.3.0)
+    snapcher (0.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/sample-app/app/models/gift.rb
+++ b/sample-app/app/models/gift.rb
@@ -1,3 +1,3 @@
 class Gift < ApplicationRecord
-  scanning column_name: "name", change_user_column: "from_user_id"
+  scanning column_name: "name", snatch_user: "from_user_id"
 end

--- a/sample-app/app/models/user.rb
+++ b/sample-app/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  scanning column_name: "role", change_user_column: "id"
+  scanning column_name: "role", snatch_user: "id"
 
   enum :role, { normal: 0, admin: 1 }
 end

--- a/spec/scanning_spec.rb
+++ b/spec/scanning_spec.rb
@@ -3,49 +3,63 @@
 require "spec_helper"
 
 RSpec.describe "Scanning" do
-  let(:user) { Models::ActiveRecord::User.create name: "Gillian Seed", role: Models::ActiveRecord::User.roles[:normal] }
+  let(:gillian) { Models::ActiveRecord::User.create name: "Gillian Seed", role: Models::ActiveRecord::User.roles[:snatcher] }
+  let(:navigator) { Models::ActiveRecord::User.create name: "Metal Gear Mk. II", role: Models::ActiveRecord::User.roles[:navigator] }
 
   context "when the column whose data has been changed is role" do
     it "scanning data will be created during create action" do
-      user # call then created.
-      expect(user.scannings.last.scannable_type).to eq("Models::ActiveRecord::User")
-      expect(user.scannings.last.column_name).to eq("role")
-      expect(user.scannings.last.action).to eq("create")
-      expect(user.scannings.last.after_params).to eq(Models::ActiveRecord::User.roles[:normal].to_s)
+      gillian # call then created.
+      expect(gillian.scannings.last.scannable_type).to eq("Models::ActiveRecord::User")
+      expect(gillian.scannings.last.column_name).to eq("role")
+      expect(gillian.scannings.last.action).to eq("create")
+      expect(gillian.scannings.last.after_params).to eq(Models::ActiveRecord::User.roles[:snatcher].to_s)
     end
 
     it "scanning data will be created during update action" do
-      user # call then created.
-      user.admin!
-      expect(user.scannings.last.scannable_type).to eq("Models::ActiveRecord::User")
-      expect(user.scannings.last.column_name).to eq("role")
-      expect(user.scannings.last.action).to eq("update")
-      expect(user.scannings.last.after_params).to eq(Models::ActiveRecord::User.roles[:admin].to_s)
+      gillian # call then created.
+      gillian.juncker!
+      expect(gillian.scannings.last.scannable_type).to eq("Models::ActiveRecord::User")
+      expect(gillian.scannings.last.column_name).to eq("role")
+      expect(gillian.scannings.last.action).to eq("update")
+      expect(gillian.scannings.last.after_params).to eq(Models::ActiveRecord::User.roles[:juncker].to_s)
     end
 
     it "scanning data will be created during destroy action" do
-      user # call then created.
-      user.destroy
-      expect(user.scannings.last.scannable_type).to eq("Models::ActiveRecord::User")
-      expect(user.scannings.last.column_name).to eq("role")
-      expect(user.scannings.last.action).to eq("destroy")
-      expect(user.scannings.last.after_params).to eq(nil)
+      gillian # call then created.
+      gillian.destroy
+      expect(gillian.scannings.last.scannable_type).to eq("Models::ActiveRecord::User")
+      expect(gillian.scannings.last.column_name).to eq("role")
+      expect(gillian.scannings.last.action).to eq("destroy")
+      expect(gillian.scannings.last.after_params).to eq(nil)
     end
   end
 
-  context "when the column whose data has been changed is role" do
-    let!(:user) do
-      Models::ActiveRecord::User.create name: "Gillian Seed", role: Models::ActiveRecord::User.roles[:normal]
+  context "when the column whose data has been changed is not role" do
+    let!(:gillian) do
+      Models::ActiveRecord::User.create name: "Gillian Seed", role: Models::ActiveRecord::User.roles[:juncker]
     end
 
     it "scanning data is not created during update action" do
-      user # call then created.
-      user.update(name: "Mika Slayton")
-      expect(user.scannings.count).to eq(1)
-      expect(user.scannings.last.scannable_type).to eq("Models::ActiveRecord::User")
-      expect(user.scannings.last.column_name).to eq("role")
-      expect(user.scannings.last.action).to eq("create")
-      expect(user.scannings.last.after_params).to eq(Models::ActiveRecord::User.roles[:normal].to_s)
+      gillian # call then created.
+      gillian.update(name: "Mika Slayton")
+      expect(gillian.scannings.count).to eq(1)
+      expect(gillian.scannings.last.scannable_type).to eq("Models::ActiveRecord::User")
+      expect(gillian.scannings.last.column_name).to eq("role")
+      expect(gillian.scannings.last.action).to eq("create")
+      expect(gillian.scannings.last.after_params).to eq(Models::ActiveRecord::User.roles[:juncker].to_s)
+    end
+  end
+
+  context "when snatch_user option is specified" do
+    let(:gillian) { Models::ActiveRecord::User.create name: "Gillian Seed", role: Models::ActiveRecord::User.roles[:juncker] }
+    let(:navigator) { Models::ActiveRecord::User.create name: "Metal Gear Mk. II", role: Models::ActiveRecord::User.roles[:navigator] }
+    let(:benson) { Models::ActiveRecord::User.create name: "Benson Cunningum", role: Models::ActiveRecord::User.roles[:juncker] }
+    let(:order) { Models::ActiveRecord::Order.create scan_user_id: gillian.id, navigate_user_id: navigator.id}
+
+    it "swap user_id update action" do
+      order # call then created.
+      order.update(scan_user_id: benson.id)
+      expect(order.scannings.last.user_id).to eq(navigator.id)
     end
   end
 end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -5,11 +5,15 @@ module Models
     class User < ::ActiveRecord::Base
       scanning column_name: "role"
 
-      enum :role, { normal: 0, admin: 1 }
+      enum :role, { snatcher: 0, navigator: 1, juncker: 2, hunter: 3 }
 
       def name
         write_attribute(:name)
       end
+    end
+
+    class Order < ::ActiveRecord::Base
+      scanning column_name: "scan_user_id", snatch_user: "navigate_user_id"
     end
   end
 end

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -40,4 +40,12 @@ ActiveRecord::Schema.define do
     t.column :user_id, :integer
     t.column :created_at, :datetime
   end
+
+  create_table :orders do |t|
+    t.column :scan_user_id, :string
+    t.column :navigate_user_id, :string
+    t.column :created_at, :datetime
+    t.column :updated_at, :datetime
+  end
+
 end


### PR DESCRIPTION
The option names have been changed to be more appropriate for this gem.
Usage is the same.

```rb
class Order < ::ActiveRecord::Base
  scanning column_name: "scan_user_id", snatch_user: "navigate_user_id"
end
```